### PR TITLE
Disable real container operation tests for CodeMagic builds

### DIFF
--- a/Modules/LibdigidocLib/Tests/LibdigidocLibTests/LibdigidocSwift/Container/ContainerWrapperTests.swift
+++ b/Modules/LibdigidocLib/Tests/LibdigidocLibTests/LibdigidocSwift/Container/ContainerWrapperTests.swift
@@ -9,6 +9,8 @@ import UtilsLibMocks
 
 @testable import LibdigidocLibSwift
 
+private let isRealContainerOperationTestsEnabled = false
+
 final class ContainerWrapperTests {
 
     private var container: ContainerWrapperProtocol = ContainerWrapper()
@@ -139,7 +141,7 @@ final class ContainerWrapperTests {
         #expect(dataFiles.count == 2)
     }
 
-    @Test
+    @Test(.enabled(if: isRealContainerOperationTestsEnabled))
     func open_success() async throws {
         let containerFile = TestFileUtil.pathForResourceFile(fileName: "example", ext: "asice")
 

--- a/Modules/LibdigidocLib/Tests/LibdigidocLibTests/LibdigidocSwift/SignedContainerTests.swift
+++ b/Modules/LibdigidocLib/Tests/LibdigidocLibTests/LibdigidocSwift/SignedContainerTests.swift
@@ -11,6 +11,8 @@ import LibdigidocLibSwiftMocks
 
 @testable import LibdigidocLibSwift
 
+private let isRealContainerOperationTestsEnabled = false
+
 final class SignedContainerTests {
 
     private let configurationProvider: ConfigurationProvider
@@ -68,7 +70,7 @@ final class SignedContainerTests {
         #expect(CommonsLib.Constants.MimeType.Asice == mimetype)
     }
 
-    @Test
+    @Test(.enabled(if: isRealContainerOperationTestsEnabled))
     func openOrCreate_success() async throws {
         let containerFile = TestFileUtil.pathForResourceFile(fileName: "example", ext: "asice")
 


### PR DESCRIPTION
**MOPPIOS-1546** 

- Disable real container operation tests for CodeMagic builds (add configurable flag).


Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
